### PR TITLE
Var: Allow transitions to be overridden

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -2,12 +2,12 @@
 
 /* Transition
 -------------------------- */
-$--all-transition: all .3s cubic-bezier(.645,.045,.355,1);
-$--fade-transition: opacity 300ms cubic-bezier(0.23, 1, 0.32, 1);
-$--fade-linear-transition: opacity 200ms linear;
-$--md-fade-transition: transform 300ms cubic-bezier(0.23, 1, 0.32, 1) 100ms, opacity 300ms cubic-bezier(0.23, 1, 0.32, 1) 100ms;
-$--border-transition-base: border-color .2s cubic-bezier(.645,.045,.355,1);
-$--color-transition-base: color .2s cubic-bezier(.645,.045,.355,1);
+$--all-transition: all .3s cubic-bezier(.645,.045,.355,1) !default;
+$--fade-transition: opacity 300ms cubic-bezier(0.23, 1, 0.32, 1) !default;
+$--fade-linear-transition: opacity 200ms linear !default;
+$--md-fade-transition: transform 300ms cubic-bezier(0.23, 1, 0.32, 1) 100ms, opacity 300ms cubic-bezier(0.23, 1, 0.32, 1) 100ms !default;
+$--border-transition-base: border-color .2s cubic-bezier(.645,.045,.355,1) !default;
+$--color-transition-base: color .2s cubic-bezier(.645,.045,.355,1) !default;
 
 /* Colors
 -------------------------- */


### PR DESCRIPTION
This allows to override transitions parameters (for example if you want them slower or faster) the same way you would tweak the primary/accent colors.

In my case, I'd need to speed up the animations a little bit, but I can't do that since the values for the $--xx-transition variables are erased during the import.


Please make sure these boxes are checked before submitting your PR, thank you!

* [ X ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ X ] Make sure you are merging your commits to `dev` branch.
* [ X ] Add some descriptions and refer relative issues for you PR.
